### PR TITLE
Add prettier config

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,7 @@
+tabWidth: 4
+overrides:
+    - files: '*.scss'
+      options:
+          tabWidth: 2
+singleQuote: true
+printWidth: 120


### PR DESCRIPTION
This is added to that when you save, prettier-atom will obey the rules that we set.

 I made our quotes single and our tabs 4 spaces. Make sure these are configured in your editor this way, otherwise it will be very annoying for you.
