### PR TITLE
Add apis to get the 3 user types with a list of ids

### DIFF
--- a/routes/api/admins.js
+++ b/routes/api/admins.js
@@ -38,6 +38,17 @@ router.get('/get/:id', (req, res, next) => {
         return res.json(post);
     });
 });
+
+//@route GET api/admins/get
+//should return admins with ids from list
+//takes json _id: []
+router.post('/get', (req, res) => {
+    Admin.find({ _id: req.body._id }, (err, admins) => {
+        if (err) return res.json({ success: false, error: err });
+        return res.json(admins);
+    });
+});
+
 // @route POST api/admins/register
 // @desc Register user
 // @access Public

--- a/routes/api/members.js
+++ b/routes/api/members.js
@@ -35,6 +35,16 @@ router.get('/get', (req, res) => {
     });
 });
 
+//@route POST api/members/get
+//should return members by ids from list
+//takes json _id:[]
+router.post('/get', (req, res) => {
+    Member.find({ _id: req.body._id }, (err, members) => {
+        if (err) return res.json({ success: false, error: err });
+        return res.json(members);
+    });
+});
+
 const validateEditInput = require('../../validation/editMember');
 
 // @route POST api/members/edit

--- a/routes/api/volunteers.js
+++ b/routes/api/volunteers.js
@@ -68,4 +68,14 @@ router.get('/get', (req, res) => {
     });
 });
 
+//@route POST api/volunteers/get
+//should return list of volunteers by id
+// teakes _id: []
+router.post('/get', (req, res) => {
+    Volunteer.find((err, volunteers) => {
+        if (err) return res.json({ success: false, error: err });
+        return res.json(volunteers);
+    });
+});
+
 module.exports = router;

--- a/test/admin_tests.js
+++ b/test/admin_tests.js
@@ -84,6 +84,19 @@ describe('Admin API suite /GET,/REGISTER,/GET/:ID,/LOGIN,/DELETE admins', () => 
             });
     });
 
+    it('it should get a list of admins', done => {
+        let idList = {
+            _id: ['"' + tempId + '"']
+        };
+        chai.request(server)
+            .post('/api/admins/get')
+            .send(idList)
+            .end((err, res) => {
+                res.should.have.status(200);
+                done();
+            });
+    });
+
     it('it should delete a specific admin', done => {
         chai.request(server)
             .delete('/api/admins/delete/' + tempId)

--- a/test/member_test.js
+++ b/test/member_test.js
@@ -96,6 +96,20 @@ describe('Members suite /ADD,/GET,/GET/:ID,/EDIT/:ID, /EDIT,/DELETE', () => {
                 done();
             });
     });
+
+    it('it should get a list of members', done => {
+        let idList = {
+            _id: ['"' + tempId + '"']
+        };
+        chai.request(server)
+            .post('/api/members/get')
+            .send(idList)
+            .end((err, res) => {
+                res.should.have.status(200);
+                done();
+            });
+    });
+
     it('it should delete a specific member', done => {
         chai.request(server)
             .delete('/api/members/delete/' + tempId)

--- a/test/volunteer_tests.js
+++ b/test/volunteer_tests.js
@@ -66,6 +66,19 @@ describe('Volunteer API suite /ADD,/GET,/GET/:ID, /DELETE', () => {
             });
     });
 
+    it('it should get a list of volunteers', done => {
+        let idList = {
+            _id: ['"' + tempId + '"']
+        };
+        chai.request(server)
+            .post('/api/volunteers/get')
+            .send(idList)
+            .end((err, res) => {
+                res.should.have.status(200);
+                done();
+            });
+    });
+
     it('it should delete a specific volunteer', done => {
         chai.request(server)
             .delete('/api/volunteers/delete/' + tempId)


### PR DESCRIPTION
I only did it for user type object because I could not think of a situation where we would need to get the others by id and not something else. This also gave me some time to investigate the mongodb - sql differences in prep for filter apis but might get used at some point.

Closes #180 