### PR TITLE
Services: Go back to services tab instead of info tab

### DIFF
--- a/client/src/actions/utils/ActionHelper.js
+++ b/client/src/actions/utils/ActionHelper.js
@@ -113,12 +113,14 @@ export default {
         axios
             .delete(`/api/${type.url}/${id}`)
             .then(res => {
+                // Call on success before dispatch so the props are the same
+                // and you can still use them inside of this function.
+                onSuccess();
+
                 dispatch({
                     type: type.delete.SUCCESS,
                     payload: res.data
                 });
-
-                onSuccess();
             })
             .catch(err => getErrors(dispatch, type, err));
     }

--- a/client/src/components/pages/services/ViewService.js
+++ b/client/src/components/pages/services/ViewService.js
@@ -32,8 +32,14 @@ export class ViewService extends Component {
         this.props.serviceActions.edit(_.get(this.props.service, '_id'), modifiedInputs, onSuccess);
     };
 
+    getMemberUrl() {
+        return `/members/${_.get(this.props.service, 'memberId')}?tab=services`;
+    }
+
     handleDeleteClick = () => {
-        this.props.serviceActions.delete(this.props.match.params.id, () => this.props.history.goBack());
+        this.props.serviceActions.delete(this.props.match.params.id, () =>
+            this.props.history.push(this.getMemberUrl())
+        );
     };
 
     getFormMarkup() {
@@ -73,7 +79,7 @@ export class ViewService extends Component {
     render() {
         return (
             <div className="view-service page-container">
-                <Link to={`/members/${_.get(this.props.service, 'memberId')}`} className="button small tertiary">
+                <Link to={this.getMemberUrl()} className="button small tertiary">
                     <i className="material-icons">keyboard_backspace</i> Back to member
                 </Link>
                 <div className="page-header">


### PR DESCRIPTION
If you click the Go back to members button on the View Service page, it goes to the services tab instead of the default tab.