### PR TITLE
Fix checkin remove activity

### DIFF
--- a/client/src/assets/stylesheets/pages/memberCheckIn.scss
+++ b/client/src/assets/stylesheets/pages/memberCheckIn.scss
@@ -89,6 +89,7 @@
         margin: 0 -0.5em;
 
         .select-activity-panel-wrapper {
+          vertical-align: top;
           display: inline-block;
           width: 33%;
 

--- a/client/src/components/pages/members/memberCheckIn/pages/SelectActivities.js
+++ b/client/src/components/pages/members/memberCheckIn/pages/SelectActivities.js
@@ -96,22 +96,14 @@ export class SelectActivities extends Component {
                                 members: [..._.remove(activity.members, this.props.memberId)]
                             });
                         }}
-                        kind="secondary">
-                        {selected ? (
-                            <>
-                                <i className="material-icons button-icon">remove_circle</i>
-                                Remove
-                            </>
-                        ) : (
-                            <>
-                                <i className="material-icons button-icon">assignment_turned_in</i>
-                                Signed up
-                            </>
-                        )}
+                        kind="secondary"
+                        icon={selected ? 'remove_circle' : 'assignment_turned_in'}>
+                        {selected ? 'Remove' : 'Signed Up'}
                     </Button>
                 </div>
             );
         }
+
         return (
             <div className="activity-button-wrapper">
                 <Button
@@ -119,8 +111,8 @@ export class SelectActivities extends Component {
                         this.props.activityActions.edit(activity._id, {
                             members: [...activity.members, this.props.memberId]
                         });
-                    }}>
-                    <i className="material-icons button-icon">assignment</i>
+                    }}
+                    icon="assignment">
                     Sign up
                 </Button>
             </div>

--- a/client/src/components/pages/members/memberCheckIn/pages/SelectActivities.js
+++ b/client/src/components/pages/members/memberCheckIn/pages/SelectActivities.js
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import _ from 'lodash';
 import moment from 'moment';
 import ActivityActions from '../../../../../actions/activityActions';
-// import Loading from '../../../ui/Loading';
 import Button from '../../../../ui/Button';
 import Utils from '../../../../../utils/Utils';
 
@@ -86,18 +85,25 @@ export class SelectActivities extends Component {
         return <p>Activities that you are signed up for will appear here</p>;
     }
 
+    removeMemberFromActivity(activity) {
+        return _.pull(activity.members, this.props.memberId);
+    }
+
+    removeActivity = activity => () => {
+        this.props.activityActions.edit(activity._id, {
+            members: this.removeMemberFromActivity(activity)
+        });
+    };
+
     getActivityButtonMarkup(activity, selected) {
         if (_.includes(activity.members, this.props.memberId)) {
             return (
                 <div className="activity-button-wrapper">
                     <Button
-                        onClick={() => {
-                            this.props.activityActions.edit(activity._id, {
-                                members: [..._.remove(activity.members, this.props.memberId)]
-                            });
-                        }}
+                        onClick={this.removeActivity(activity)}
                         kind="secondary"
-                        icon={selected ? 'remove_circle' : 'assignment_turned_in'}>
+                        icon={selected ? 'remove_circle' : 'assignment_turned_in'}
+                        disabled={this.props.activitiesLoading}>
                         {selected ? 'Remove' : 'Signed Up'}
                     </Button>
                 </div>
@@ -112,7 +118,8 @@ export class SelectActivities extends Component {
                             members: [...activity.members, this.props.memberId]
                         });
                     }}
-                    icon="assignment">
+                    icon="assignment"
+                    disabled={this.props.activitiesLoading}>
                     Sign up
                 </Button>
             </div>


### PR DESCRIPTION
Wait until #431 is merged before merging this one. (It shares a commit).

Fix remove activity in member check in.

It used to just clear the entire array of members in the activity.
Should be using _.pull instead of _.remove
Also adds disabled prop to the sign up activity buttons.